### PR TITLE
#23 create fake variation value when not given

### DIFF
--- a/src/Component/ComponentItemFactory.php
+++ b/src/Component/ComponentItemFactory.php
@@ -129,7 +129,7 @@ readonly class ComponentItemFactory
             if (\is_array($type)) {
                 $paramValue = $this->createVariationParameters($type, $variation[$name] ?? []);
             } else {
-                $paramValue = $this->faker->getFakeData([$name => $type], $variation[$name]);
+                $paramValue = $this->faker->getFakeData([$name => $type], $variation[$name] ?? []);
             }
             $params += $paramValue;
         }

--- a/tests/Functional/Service/ComponentItemFactoryTest.php
+++ b/tests/Functional/Service/ComponentItemFactoryTest.php
@@ -207,6 +207,38 @@ class ComponentItemFactoryTest extends KernelTestCase
         static::assertEquals('Mitsubishi', $car->getManufacturer()->getName());
     }
 
+    public function testCreateForParamWithOptionalVariationValue()
+    {
+        $data = [
+            'name' => 'component',
+            'title' => 'title',
+            'description' => 'description',
+            'category' => 'MainCategory',
+            'path' => 'path',
+            'renderPath' => 'renderPath',
+            'parameters' => [
+                'stringParam' => 'String',
+                'secondParam' => 'String',
+            ],
+            'variations' => [
+                'variation1' => [
+                    'stringParam' => 'Some cool hipster text',
+                ],
+            ],
+        ];
+
+        /** @var ComponentItemFactory $factory */
+        $factory = self::getContainer()->get('twig_doc.service.component_factory');
+
+        $item = $factory->create($data);
+        $variations = $item->getVariations();
+
+        self::assertIsArray($variations);
+        self::assertArrayHasKey('variation1', $variations);
+        self::assertArrayHasKey('secondParam', $variations['variation1']);
+        self::assertIsString($variations['variation1']['secondParam']);
+    }
+
     public static function getInvalidComponentConfigurationTestCases(): iterable
     {
         yield [

--- a/tests/Functional/Service/ComponentItemFactoryTest.php
+++ b/tests/Functional/Service/ComponentItemFactoryTest.php
@@ -207,7 +207,7 @@ class ComponentItemFactoryTest extends KernelTestCase
         static::assertEquals('Mitsubishi', $car->getManufacturer()->getName());
     }
 
-    public function testCreateForParamWithOptionalVariationValue()
+    public function testCreateForParamWithOptionalVariationValue(): void
     {
         $data = [
             'name' => 'component',


### PR DESCRIPTION
Closes #23 by creating fake variation value when none is given in components configuration.