### PR TITLE
Add possibility to pass empty variation value to keep param empty

### DIFF
--- a/src/Component/ComponentItemFactory.php
+++ b/src/Component/ComponentItemFactory.php
@@ -129,7 +129,7 @@ readonly class ComponentItemFactory
             if (\is_array($type)) {
                 $paramValue = $this->createVariationParameters($type, $variation[$name] ?? []);
             } else {
-                $paramValue = $this->faker->getFakeData([$name => $type], $variation[$name] ?? []);
+                $paramValue = $this->faker->getFakeData([$name => $type], $variation[$name] ?? null);
             }
             $params += $paramValue;
         }

--- a/src/Component/ComponentItemFactory.php
+++ b/src/Component/ComponentItemFactory.php
@@ -129,7 +129,7 @@ readonly class ComponentItemFactory
             if (\is_array($type)) {
                 $paramValue = $this->createVariationParameters($type, $variation[$name] ?? []);
             } else {
-                $paramValue = $this->faker->getFakeData([$name => $type], $variation[$name]);
+                $paramValue = $this->faker->getFakeData([$name => $type], $variation[$name] ?? []);
             }
             $params += $paramValue;
         }

--- a/src/Component/Data/Faker.php
+++ b/src/Component/Data/Faker.php
@@ -17,7 +17,7 @@ class Faker
     ) {
     }
 
-    public function getFakeData(array $params, mixed $variation = []): array
+    public function getFakeData(array $params, mixed $variation = null): array
     {
         return $this->createFakeData($params, $variation);
     }
@@ -34,7 +34,7 @@ class Faker
             }
 
             foreach ($this->generators as $generator) {
-                if (\array_key_exists($name, $result) || !$generator->supports($type)) {
+                if (\array_key_exists($name, $result)) {
                     continue;
                 }
                 if ($generator->supports($type, $variation)) {

--- a/src/Component/Data/Generator/ScalarGenerator.php
+++ b/src/Component/Data/Generator/ScalarGenerator.php
@@ -21,7 +21,7 @@ class ScalarGenerator implements GeneratorInterface
     public function supports(string $type, mixed $context = null): bool
     {
         // context normally contains the param values for a specific variation, so we generate random values only for non-set params
-        return empty($context) && \in_array(strtolower($type), [
+        return null === $context && \in_array(strtolower($type), [
             Type::BUILTIN_TYPE_BOOL,
             Type::BUILTIN_TYPE_FLOAT,
             Type::BUILTIN_TYPE_INT,

--- a/tests/Functional/Service/ComponentItemFactoryTest.php
+++ b/tests/Functional/Service/ComponentItemFactoryTest.php
@@ -219,10 +219,12 @@ class ComponentItemFactoryTest extends KernelTestCase
             'parameters' => [
                 'stringParam' => 'String',
                 'secondParam' => 'String',
+                'optionalEmpty' => 'String',
             ],
             'variations' => [
                 'variation1' => [
                     'stringParam' => 'Some cool hipster text',
+                    'optionalEmpty' => '',
                 ],
             ],
         ];
@@ -237,6 +239,7 @@ class ComponentItemFactoryTest extends KernelTestCase
         self::assertArrayHasKey('variation1', $variations);
         self::assertArrayHasKey('secondParam', $variations['variation1']);
         self::assertIsString($variations['variation1']['secondParam']);
+        self::assertNull($variations['variation1']['optionalEmpty']);
     }
 
     public static function getInvalidComponentConfigurationTestCases(): iterable

--- a/tests/Functional/Service/ComponentItemFactoryTest.php
+++ b/tests/Functional/Service/ComponentItemFactoryTest.php
@@ -207,6 +207,38 @@ class ComponentItemFactoryTest extends KernelTestCase
         static::assertEquals('Mitsubishi', $car->getManufacturer()->getName());
     }
 
+    public function testCreateForParamWithOptionalVariationValue()
+    {
+        $data = [
+            'name' => 'component',
+            'title' => 'title',
+            'description' => 'description',
+            'category' => 'MainCategory',
+            'path' => 'path',
+            'renderPath' => 'renderPath',
+            'parameters' => [
+                'stringParam' => 'String',
+                'secondParam' => 'String',
+            ],
+            'variations' => [
+                'variation1' => [
+                    'stringParam' => 'Some cool hipster text',
+                ],
+            ],
+        ];
+
+        /** @var ComponentItemFactory $factory */
+        $factory = self::getContainer()->get('twig_doc.service.component_factory');
+
+        $item = $factory->create($data);
+        $variations = $item->getVariations();
+
+        self::assertIsArray($variations);
+        self::assertArrayHasKey('variation1', $variations);
+        self::assertArrayHasKey('secondParam', $variations['variation1']);
+        self::assertIsString($variations['variation1']['secondParam']);
+    }
+
     public static function getInvalidComponentConfigurationTestCases(): iterable
     {
         yield [

--- a/tests/Functional/Service/ComponentItemFactoryTest.php
+++ b/tests/Functional/Service/ComponentItemFactoryTest.php
@@ -207,7 +207,7 @@ class ComponentItemFactoryTest extends KernelTestCase
         static::assertEquals('Mitsubishi', $car->getManufacturer()->getName());
     }
 
-    public function testCreateForParamWithOptionalVariationValue()
+    public function testCreateForParamWithOptionalVariationValue(): void
     {
         $data = [
             'name' => 'component',


### PR DESCRIPTION
When giving a parameter value in a variation as empty string, it will be provided as NULL in component-view:
```
variations:
  default:
    param1: ''
```

When the parameter is left out of the variation, it is generated as random fake-data as before.